### PR TITLE
Fix message regeneration issue with dynamic offer_price

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+Issue to solve: https://github.com/FreePhoenix888/warframe-market-ducats-buyer/issues/5
+Your prepared branch: issue-5-3895ab17d0fb
+Your prepared working directory: /tmp/gh-issue-solver-1762339316030
+Your forked repository: konard/warframe-market-ducats-buyer
+Original repository (upstream): FreePhoenix888/warframe-market-ducats-buyer
+
+Proceed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,0 @@
-Issue to solve: https://github.com/FreePhoenix888/warframe-market-ducats-buyer/issues/5
-Your prepared branch: issue-5-3895ab17d0fb
-Your prepared working directory: /tmp/gh-issue-solver-1762339316030
-Your forked repository: konard/warframe-market-ducats-buyer
-Original repository (upstream): FreePhoenix888/warframe-market-ducats-buyer
-
-Proceed.

--- a/src/external_lib/external.rs
+++ b/src/external_lib/external.rs
@@ -379,14 +379,14 @@ pub async fn fetch_all_orders(
 }
 
 /// Processes the orders by filtering, enriching fields, sorting.
-pub fn process_orders(orders: Vec<Order>,  filter: impl Fn(&Order) -> bool) -> Vec<Order> {
+pub fn process_orders(orders: Vec<Order>,  filter: impl Fn(&Order) -> bool, offer_price: u32) -> Vec<Order> {
     let mut grouped_orders: HashMap<String, Vec<Order>> = HashMap::new();
 
     let filtered_orders: Vec<Order> = orders.into_iter().filter(|order| filter(order)).collect();
 
     for mut order in filtered_orders {
         order.is_with_group = Some(false);
-        order.price_to_offer = Some(cmp::min(PRICE_TO_OFFER, order.platinum));
+        order.price_to_offer = Some(cmp::min(offer_price, order.platinum));
         order.sum_to_offer = Some(order.price_to_offer.unwrap() * order.quantity);
         grouped_orders
             .entry(order.user.ingame_name.clone())
@@ -456,6 +456,14 @@ pub fn generate_message(order: &Order, desired_price: u32) -> String {
     }
 }
 
+
+/// Generates a message for a single order using the stored price_to_offer.
+/// This should be used when displaying messages for processed orders,
+/// to ensure the message reflects the offer price at the time of processing.
+pub fn generate_message_from_order(order: &Order) -> String {
+    let price_to_offer = order.price_to_offer.expect("Order must have price_to_offer set by process_orders");
+    generate_message(order, price_to_offer)
+}
 
 /// Generates messages for all processed orders.
 pub fn generate_messages(orders: &[Order], desired_price: u32) -> Vec<String> {

--- a/src/external_lib/mod.rs
+++ b/src/external_lib/mod.rs
@@ -13,4 +13,5 @@ pub use external::MAX_PRICE_TO_SEARCH;
 pub use external::fetch_all_orders;
 pub use external::process_orders;
 pub use external::generate_message;
+pub use external::generate_message_from_order;
 pub use external::generate_messages;

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -8,6 +8,7 @@ pub use crate::external_lib::PROFITABLE_ITEM_NAMES;
 pub use crate::external_lib::fetch_all_orders;
 pub use crate::external_lib::process_orders;
 pub use crate::external_lib::generate_message;
+pub use crate::external_lib::generate_message_from_order;
 pub use crate::external_lib::generate_messages;
 pub use crate::external_lib::PRICE_TO_OFFER;
 pub use crate::external_lib::MIN_QUANTITY_TO_SEARCH;

--- a/src/main.rs
+++ b/src/main.rs
@@ -208,6 +208,7 @@ impl eframe::App for MyApp {
                   self.settings_manager.contacted_order_ids().iter().cloned().collect();
               let ignored_nicknames = self.settings_manager.ignored_user_nicknames().iter().cloned().collect::<std::collections::HashSet<_>>();
 
+              let offer_price = offer_price;
               std::thread::spawn(move || {
                 let filter_orders = |order: &lib::Order| -> bool {
                   order.user.status == "ingame"
@@ -220,7 +221,7 @@ impl eframe::App for MyApp {
                 };
 
                 let processed_orders = orders
-                    .map(|o| lib::process_orders(o, filter_orders))
+                    .map(|o| lib::process_orders(o, filter_orders, offer_price))
                     .unwrap_or_else(Vec::new);
                 let _ = tx.send(Ok(processed_orders));
               });
@@ -247,8 +248,7 @@ impl eframe::App for MyApp {
                 Stroke::new(1.0, ui.visuals().extreme_bg_color)
               };
 
-              // TODO: messages regenerate every time so new offer_price is applied but it should not apply until we click filter & process ordeers button
-              let message = lib::generate_message(order, offer_price);
+              let message = lib::generate_message_from_order(order);
 
               Frame::none()
                   .stroke(frame_stroke)


### PR DESCRIPTION
## Summary
This PR fixes issue #5 where messages were regenerating every frame with the current offer_price from settings, instead of using the price that was active when orders were processed.

## Problem
Previously, in `main.rs:250-251`, the message generation code was:
```rust
// TODO: messages regenerate every time so new offer_price is applied but it should not apply until we click filter & process ordeers button
let message = lib::generate_message(order, offer_price);
```

This caused messages to regenerate every frame using the **current** `offer_price` value from settings. When users changed the "price to offer" setting in the UI, all displayed messages would immediately update with the new price, even though the orders were processed with a different price.

## Solution
The fix involves storing the `offer_price` that was active when "Filter & Process Orders" was clicked, and using that stored value for message generation:

1. **Modified `process_orders()` function** (`src/external_lib/external.rs:382`): Now accepts an `offer_price` parameter and stores it in each order's `price_to_offer` field instead of using the hardcoded `PRICE_TO_OFFER` constant.

2. **Added `generate_message_from_order()` function** (`src/external_lib/external.rs:463`): A new function that reads the stored `price_to_offer` from the order object instead of taking it as a parameter.

3. **Updated processing logic** (`src/main.rs:211,224`): Captures the `offer_price` value at the time of clicking "Filter & Process Orders" and passes it to `process_orders()`.

4. **Updated message generation** (`src/main.rs:251`): Changed from `generate_message(order, offer_price)` to `generate_message_from_order(order)`, ensuring messages use the stored price.

## Result
Now when users click "Filter & Process Orders", the `offer_price` at that moment is captured and stored with each processed order. Messages will always display with that price, preventing unwanted regeneration when settings are changed.

## Changes
- `src/external_lib/external.rs`: Modified `process_orders()` signature and added `generate_message_from_order()`
- `src/external_lib/mod.rs`: Exported new function
- `src/lib/mod.rs`: Re-exported new function
- `src/main.rs`: Updated to pass `offer_price` to processing and use new message generation function

Fixes #5

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)